### PR TITLE
feat: Add automated version bump and crates.io publish workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -67,7 +67,7 @@ jobs:
       
       - name: Publish to crates.io
         run: |
-          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Configure Git
         run: |
-          git config --local user.email "eethiran@users.noreply.github.com"
-          git config --local user.name "eethiran"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
 
       - name: Commit version bump
         run: |

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,98 @@
+name: Version Bump on PR Merge
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  version-bump:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+
+      - name: Install cargo-edit
+        run: cargo install cargo-edit
+
+      - name: Get current version
+        id: get_version
+        run: |
+          CURRENT_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "current_version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          echo "Current version: $CURRENT_VERSION"
+
+      - name: Bump minor version
+        run: |
+          cargo set-version --bump minor
+          NEW_VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].version')
+          echo "New version: $NEW_VERSION"
+          echo "new_version=$NEW_VERSION" >> $GITHUB_ENV
+
+      - name: Configure Git
+        run: |
+          git config --local user.email "eethiran@users.noreply.github.com"
+          git config --local user.name "eethiran"
+
+      - name: Commit version bump
+        run: |
+          git add Cargo.toml Cargo.lock
+          git commit -m "Release v${{ env.new_version }}"
+
+      - name: Create and push tag
+        run: |
+          git tag "v${{ env.new_version }}"
+          git push origin HEAD:main
+          git push origin "v${{ env.new_version }}"
+      
+      - name: Build release artifacts
+        run: |
+          cargo build --release
+          cargo test --release
+      
+      - name: Publish to crates.io
+        run: |
+          cargo publish --token ${{ secrets.CARGO_REGISTRY_TOKEN }}
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Create GitHub Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ env.new_version }}
+          release_name: Release v${{ env.new_version }}
+          body: |
+            ## Changes in this release
+
+            This release was automatically created from PR #${{ github.event.pull_request.number }}
+
+            **PR Title:** ${{ github.event.pull_request.title }}
+
+            **Merged by:** @${{ github.event.pull_request.merged_by.login }}
+            
+            ### Published to crates.io
+            This version has been published to [crates.io](https://crates.io/crates/gonfig) and is available for use in your projects.
+            
+            ```toml
+            [dependencies]
+            gonfig = "${{ env.new_version }}"
+            ```
+          draft: false
+          prerelease: false


### PR DESCRIPTION
## Summary
- Added GitHub Actions workflow for automatic version management
- Automatically bumps minor version when PRs are merged to main
- Publishes new versions to crates.io for public use

## Changes
- Created `.github/workflows/version-bump.yml` workflow that:
  - Triggers on PR merge to main branch
  - Bumps minor version using cargo-edit
  - Builds and tests the crate in release mode
  - Publishes to crates.io (requires `CARGO_REGISTRY_TOKEN` secret)
  - Creates GitHub release with PR details
  - Includes crates.io installation instructions in release notes

## Setup Required
Before merging, please add the `CARGO_REGISTRY_TOKEN` secret in the repository settings:
1. Go to Settings → Secrets and variables → Actions
2. Add a new repository secret named `CARGO_REGISTRY_TOKEN`
3. Set the value to your crates.io API token

## Test Plan
- [x] Workflow file is syntactically valid
- [x] Crate builds successfully
- [ ] Will be tested on merge to main