### PR TITLE
fix: Use single-threaded tests in version-bump workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -61,7 +61,7 @@ jobs:
       - name: Build release artifacts
         run: |
           cargo build --release
-          cargo test --release
+          cargo test --release -- --test-threads=1
       
       - name: Push tag
         run: |


### PR DESCRIPTION
## Problem
The version-bump workflow was failing in the "Build release artifacts" step due to environment variable pollution in parallel test execution.

## Solution
Added `--test-threads=1` to the `cargo test --release` command in the version-bump workflow to prevent environment variable pollution between parallel tests.

## Changes
- Updated `.github/workflows/version-bump.yml` to use single-threaded testing
- This matches the fix applied to the CI workflow

## Testing
- [x] Pre-commit hooks pass locally
- [x] All tests pass with single-threaded execution

Fixes the failing workflow: https://github.com/itsparser/gonfig/actions/runs/18002177389/job/51213872882