### PR TITLE
fix: Publish derive crate before main crate in workflow

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -124,6 +124,18 @@ jobs:
       - name: Publish to crates.io
         if: steps.check_version.outputs.version_exists == 'false'
         run: |
+          # First publish the derive crate
+          echo "Publishing gonfig_derive crate..."
+          cd gonfig_derive
+          cargo publish
+          cd ..
+          
+          # Wait a moment for the derive crate to be available
+          echo "Waiting for derive crate to be available..."
+          sleep 30
+          
+          # Then publish the main crate
+          echo "Publishing main gonfig crate..."
           cargo publish
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Problem
The version-bump workflow was failing during the "Publish to crates.io" step because the main crate depends on a specific version of gonfig_derive that hasn't been published yet.

## Root Cause
- Main crate `Cargo.toml` specifies `gonfig_derive = "0.1.5"`
- When we try to publish the main crate, cargo looks for version 0.1.5 of gonfig_derive on crates.io
- But gonfig_derive 0.1.5 hasn't been published yet, causing the publish to fail

## Solution
- **Publish order**: First publish gonfig_derive, then the main crate
- **Wait period**: Add a 30-second wait between publishes to ensure the derive crate is available
- **Clear messaging**: Added log messages to show which crate is being published

## Changes
- Modified publish step to handle both crates in the correct order
- Added sleep between publishes to allow crates.io indexing
- Enhanced logging for better debugging

## Testing
- [x] Workflow logic validated
- [x] Dependency resolution should work correctly
- [x] Pre-commit hooks pass

This fix ensures that both crates are published in the correct dependency order, resolving the cargo dependency resolution error.