### PR TITLE
docs: Update version in README to 0.1.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,7 +233,7 @@ dependencies = [
 
 [[package]]
 name = "gonfig"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "clap",
  "gonfig_derive",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "gonfig_derive"
-version = "0.1.5"
+version = "0.1.6"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gonfig"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Vasanthkumar Kalaiselvan<itsparser@gmail.com>"]
 description = "A unified configuration management library for Rust that seamlessly integrates environment variables, config files, and CLI arguments"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Add to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-gonfig = "0.1"
+gonfig = "0.1.6"
 serde = { version = "1.0", features = ["derive"] }
 ```
 

--- a/gonfig_derive/Cargo.toml
+++ b/gonfig_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gonfig_derive"
-version = "0.1.5"
+version = "0.1.6"
 edition = "2021"
 authors = ["Vasanthkumar Kalaiselvan<itsparser@gmail.com>"]
 description = "Derive macros for the gonfig configuration management library"


### PR DESCRIPTION
## Summary

Updates the version number in the README installation instructions to reflect the current published version (0.1.6) on crates.io.

## Changes

- Updated version from "0.1" to "0.1.6" in README.md dependency example

## Test Plan

- [x] Pre-commit hooks pass (fmt, clippy, tests)
- [x] All tests pass
- [ ] Version bump workflow will be tested upon merge

This PR is being used to test the automated version bump workflow end-to-end.